### PR TITLE
Fix: 2 Player in game can't be controlled by 2nd wiimote

### DIFF
--- a/source/Wii/kbdlib.c
+++ b/source/Wii/kbdlib.c
@@ -581,12 +581,12 @@ static void ProcessJoystickDirection(KBDHANDLE kbdHandle, int channel, joystick_
     }
 }
 
-static void ProcessWPadButtons(KBDHANDLE kbdHandle, u32 buttons, PADCODE *wpad)
+static void ProcessWPadButtons(KBDHANDLE kbdHandle,int channel, u32 buttons, PADCODE *wpad)
 {
     int i, idx_new  = kbdHandle->keyidx ^ 1;
     for(i = 0; wpad[i].key_a != KEY_NONE; i++)  {
         if( (buttons & wpad[i].code) != 0  ) {
-            kbdHandle->btnstatus[idx_new][wpad[i].key_a-KEY_JOY_FIRST] = 1;
+            kbdHandle->btnstatus[idx_new][(channel?wpad[i].key_b:wpad[i].key_a)-KEY_JOY_FIRST] = 1;
         }
     }
 }
@@ -600,30 +600,30 @@ void KBD_GetPadButtonStatus(int channel)
 
     // Check GameCube buttons
     buttons = PAD_ButtonsHeld(channel);
-    ProcessWPadButtons(kbdHandle, buttons, pad_default);
+    ProcessWPadButtons(kbdHandle, channel, buttons, pad_default);
 
     // Check WiiMote buttons
     buttons = WPAD_ButtonsHeld(channel);
 
     // Key translations for default WiiMote buttons
-    ProcessWPadButtons(kbdHandle, buttons, wpad_default);
+    ProcessWPadButtons(kbdHandle, channel, buttons, wpad_default);
     if( wpad_orientation == WPADO_HORIZONTAL ) {
-        ProcessWPadButtons(kbdHandle, buttons, wpad_horizontal);
+        ProcessWPadButtons(kbdHandle, channel, buttons, wpad_horizontal);
     }else{
-        ProcessWPadButtons(kbdHandle, buttons, wpad_vertical);
+        ProcessWPadButtons(kbdHandle, channel, buttons, wpad_vertical);
     }
 
     // Check extensions
     WPAD_Probe(channel, &extensions);
     if( extensions == WPAD_EXP_NUNCHUK ) {
       // Nunchuck button translations
-      ProcessWPadButtons(kbdHandle, buttons, wpad_nunchuk);
+      ProcessWPadButtons(kbdHandle, channel, buttons, wpad_nunchuk);
       // Nunchuk stick
       WPAD_Expansion(channel, &data.exp);
       ProcessJoystickDirection(kbdHandle, channel, &data.exp.nunchuk.js);
     } else if( extensions == WPAD_EXP_CLASSIC ) {
       // Classic controller button translations
-      ProcessWPadButtons(kbdHandle, buttons, wpad_classic);
+      ProcessWPadButtons(kbdHandle, channel, buttons, wpad_classic);
       // Both classic controller sticks
       WPAD_Expansion(channel, &data.exp);
       ProcessJoystickDirection(kbdHandle, channel, &data.exp.classic.ljs);


### PR DESCRIPTION
Because the 2nd wiimote works as same as 1st wiimote, 1 Player in game is controlled by both 1st and 2nd wiimote, but 2 Player in game is not controlled by any wiimote

This problem is caused by ignoring channel information in handling WPAD input